### PR TITLE
fix SQL field name; fix API camel case; update civix boilerplate

### DIFF
--- a/api/v3/Job/ProcessOfflineRecurringPayments.mgd.php
+++ b/api/v3/Job/ProcessOfflineRecurringPayments.mgd.php
@@ -1,16 +1,16 @@
 <?php
 return [
   0 => [
-    'name' => 'Cron:Job.ProcessOfflineRecurringPayments',
+    'name' => 'Cron:Job.processofflinerecurringpayments',
     'entity' => 'Job',
     'update' => 'never',
     'params' => [
       'version' => 3,
-      'name' => 'Job.ProcessOfflineRecurringPayments',
-      'description' => 'Call Job.ProcessOfflineRecurringPayments API',
+      'name' => 'Job.processofflinerecurringpayments',
+      'description' => 'Call Job.processofflinerecurringpayments API',
       'run_frequency' => 'Hourly',
       'api_entity' => 'Job',
-      'api_action' => 'ProcessOfflineRecurringPayments',
+      'api_action' => 'processofflinerecurringpayments',
       'parameters' => '',
     ],
   ],

--- a/api/v3/Job/Processofflinerecurringpayments.php
+++ b/api/v3/Job/Processofflinerecurringpayments.php
@@ -2,7 +2,7 @@
 use _ExtensionUtil as E;
 
 /**
- * Job.ProcessOfflineRecurringPayments API
+ * Job.processofflinerecurringpayments API
  *
  * @param array $params
  * @return array API result descriptor
@@ -10,7 +10,7 @@ use _ExtensionUtil as E;
  * @see civicrm_api3_create_error
  * @throws API_Exception
  */
-function civicrm_api3_job_ProcessOfflineRecurringPayments($params) {
+function civicrm_api3_job_processofflinerecurringpayments($params) {
   // 7 day lookback - prevents contributions stopping if cron fails to run for up to 7 days
   $searchStart = date('Y-m-d H:i:s', strtotime('today') - (7 * 86400));
   $searchEnd   = date('Y-m-d H:i:s', strtotime('today') + 86399);
@@ -20,8 +20,8 @@ function civicrm_api3_job_ProcessOfflineRecurringPayments($params) {
     SELECT * FROM civicrm_contribution_recur ccr
       INNER JOIN civicrm_contribution_recur_offline ccro ON ccro.contribution_recur_id = ccr.id
     WHERE (ccr.end_date IS NULL OR ccr.end_date > NOW())
-      AND ccr.next_sched_contribution >= %1
-      AND ccr.next_sched_contribution <= %2
+      AND ccr.next_sched_contribution_date >= %1
+      AND ccr.next_sched_contribution_date <= %2
   ";
 
   $dao = CRM_Core_DAO::executeQuery($sql, [

--- a/offlinerecurring.civix.php
+++ b/offlinerecurring.civix.php
@@ -82,7 +82,7 @@ use CRM_OfflineRecurring_ExtensionUtil as E;
 /**
  * (Delegated) Implements hook_civicrm_config().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_config
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
  */
 function _offlinerecurring_civix_civicrm_config(&$config = NULL) {
   static $configured = FALSE;
@@ -112,7 +112,7 @@ function _offlinerecurring_civix_civicrm_config(&$config = NULL) {
  *
  * @param $files array(string)
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_xmlMenu
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_xmlMenu
  */
 function _offlinerecurring_civix_civicrm_xmlMenu(&$files) {
   foreach (_offlinerecurring_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
@@ -123,7 +123,7 @@ function _offlinerecurring_civix_civicrm_xmlMenu(&$files) {
 /**
  * Implements hook_civicrm_install().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
  */
 function _offlinerecurring_civix_civicrm_install() {
   _offlinerecurring_civix_civicrm_config();
@@ -135,7 +135,7 @@ function _offlinerecurring_civix_civicrm_install() {
 /**
  * Implements hook_civicrm_postInstall().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_postInstall
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
  */
 function _offlinerecurring_civix_civicrm_postInstall() {
   _offlinerecurring_civix_civicrm_config();
@@ -149,7 +149,7 @@ function _offlinerecurring_civix_civicrm_postInstall() {
 /**
  * Implements hook_civicrm_uninstall().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
  */
 function _offlinerecurring_civix_civicrm_uninstall() {
   _offlinerecurring_civix_civicrm_config();
@@ -161,7 +161,7 @@ function _offlinerecurring_civix_civicrm_uninstall() {
 /**
  * (Delegated) Implements hook_civicrm_enable().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_enable
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
  */
 function _offlinerecurring_civix_civicrm_enable() {
   _offlinerecurring_civix_civicrm_config();
@@ -175,7 +175,7 @@ function _offlinerecurring_civix_civicrm_enable() {
 /**
  * (Delegated) Implements hook_civicrm_disable().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_disable
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
  * @return mixed
  */
 function _offlinerecurring_civix_civicrm_disable() {
@@ -196,7 +196,7 @@ function _offlinerecurring_civix_civicrm_disable() {
  * @return mixed  based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
  *                for 'enqueue', returns void
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_upgrade
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
  */
 function _offlinerecurring_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
   if ($upgrader = _offlinerecurring_civix_upgrader()) {
@@ -259,20 +259,21 @@ function _offlinerecurring_civix_find_files($dir, $pattern) {
  *
  * Find any *.mgd.php files, merge their content, and return.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_managed
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
  */
 function _offlinerecurring_civix_civicrm_managed(&$entities) {
   $mgdFiles = _offlinerecurring_civix_find_files(__DIR__, '*.mgd.php');
+  sort($mgdFiles);
   foreach ($mgdFiles as $file) {
     $es = include $file;
     foreach ($es as $e) {
       if (empty($e['module'])) {
         $e['module'] = E::LONG_NAME;
       }
-      $entities[] = $e;
       if (empty($e['params']['version'])) {
         $e['params']['version'] = '3';
       }
+      $entities[] = $e;
     }
   }
 }
@@ -284,7 +285,7 @@ function _offlinerecurring_civix_civicrm_managed(&$entities) {
  *
  * Note: This hook only runs in CiviCRM 4.4+.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_caseTypes
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
 function _offlinerecurring_civix_civicrm_caseTypes(&$caseTypes) {
   if (!is_dir(__DIR__ . '/xml/case')) {
@@ -313,7 +314,7 @@ function _offlinerecurring_civix_civicrm_caseTypes(&$caseTypes) {
  *
  * Note: This hook only runs in CiviCRM 4.5+.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
 function _offlinerecurring_civix_civicrm_angularModules(&$angularModules) {
   if (!is_dir(__DIR__ . '/ang')) {
@@ -328,6 +329,25 @@ function _offlinerecurring_civix_civicrm_angularModules(&$angularModules) {
       $module['ext'] = E::LONG_NAME;
     }
     $angularModules[$name] = $module;
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_themes().
+ *
+ * Find any and return any files matching "*.theme.php"
+ */
+function _offlinerecurring_civix_civicrm_themes(&$themes) {
+  $files = _offlinerecurring_civix_glob(__DIR__ . '/*.theme.php');
+  foreach ($files as $file) {
+    $themeMeta = include $file;
+    if (empty($themeMeta['name'])) {
+      $themeMeta['name'] = preg_replace(':\.theme\.php$:', '', basename($file));
+    }
+    if (empty($themeMeta['ext'])) {
+      $themeMeta['ext'] = E::LONG_NAME;
+    }
+    $themes[$themeMeta['name']] = $themeMeta;
   }
 }
 
@@ -431,17 +451,11 @@ function _offlinerecurring_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $pa
 /**
  * (Delegated) Implements hook_civicrm_alterSettingsFolders().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
  */
 function _offlinerecurring_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  static $configured = FALSE;
-  if ($configured) {
-    return;
-  }
-  $configured = TRUE;
-
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (is_dir($settingsDir) && !in_array($settingsDir, $metaDataFolders)) {
+  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
     $metaDataFolders[] = $settingsDir;
   }
 }
@@ -451,7 +465,7 @@ function _offlinerecurring_civix_civicrm_alterSettingsFolders(&$metaDataFolders 
  *
  * Find any *.entityType.php files, merge their content, and return.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_entityTypes
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
  */
 
 function _offlinerecurring_civix_civicrm_entityTypes(&$entityTypes) {

--- a/tests/phpunit/api/v3/Job/ProcessOfflineRecurringPaymentsTest.php
+++ b/tests/phpunit/api/v3/Job/ProcessOfflineRecurringPaymentsTest.php
@@ -5,11 +5,11 @@ use Civi\Test\HookInterface;
 use Civi\Test\TransactionalInterface;
 
 /**
- * Job.ProcessOfflineRecurringPayments API Test Case
+ * Job.processofflinerecurringpayments API Test Case
  * This is a generic test class implemented with PHPUnit.
  * @group headless
  */
-class api_v3_Job_ProcessOfflineRecurringPaymentsTest extends \PHPUnit_Framework_TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+class api_v3_Job_ProcessofflinerecurringpaymentsTest extends \PHPUnit_Framework_TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
 
   /**
    * Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
@@ -42,7 +42,7 @@ class api_v3_Job_ProcessOfflineRecurringPaymentsTest extends \PHPUnit_Framework_
    * Note how the function name begins with the word "test".
    */
   public function testApiExample() {
-    $result = civicrm_api3('Job', 'ProcessOfflineRecurringPayments', array('magicword' => 'sesame'));
+    $result = civicrm_api3('Job', 'processofflinerecurringpayments', array('magicword' => 'sesame'));
     $this->assertEquals('Twelve', $result['values'][12]['name']);
   }
 


### PR DESCRIPTION
Hi Pradeep,

I'm not sure if you have any interest in merging PRs on this extension; if not, let me know and I'll maintain this fork as the most recent version.

I installed your rewritten version, and it needed a couple of tweaks to get working:
* the API couldn't be found.  I traced it down to a camelCase issue.
* The SQL in the scheduled job needed some fields renamed.
* I also updated the civix boilerplate - I thought the "API not found" error was due to an old civix file.  It wasn't, but I kept it anyway as an improvement.

I may take some time to expand this a bit further to let the user decide whether the generated payments should be pending or completed; I'll check with my client.

Jon