### PR TITLE
fix SQL to avoid updating wrong recurring contribution date; make nex…

### DIFF
--- a/CRM/OfflineRecurring/Form/RecurringContribution.php
+++ b/CRM/OfflineRecurring/Form/RecurringContribution.php
@@ -122,7 +122,7 @@ class CRM_OfflineRecurring_Form_RecurringContribution extends CRM_Core_Form {
     CRM_Contribute_Form_Contribution_Main::buildRecur($this);
     foreach ([
       'start_date' => TRUE,
-      'next_sched_contribution_date' => FALSE,
+      'next_sched_contribution_date' => TRUE,
       'end_date' => FALSE,
     ] as $field => $isRequired) {
       $this->addField($field, ['entity' => 'ContributionRecur'], $isRequired, FALSE);

--- a/api/v3/Job/Processofflinerecurringpayments.php
+++ b/api/v3/Job/Processofflinerecurringpayments.php
@@ -17,11 +17,12 @@ function civicrm_api3_job_processofflinerecurringpayments($params) {
 
   // Select the recurring payment, where current date is equal to next scheduled date
   $sql = "
-    SELECT * FROM civicrm_contribution_recur ccr
+    SELECT ccr.* FROM civicrm_contribution_recur ccr
       INNER JOIN civicrm_contribution_recur_offline ccro ON ccro.contribution_recur_id = ccr.id
     WHERE (ccr.end_date IS NULL OR ccr.end_date > NOW())
       AND ccr.next_sched_contribution_date >= %1
       AND ccr.next_sched_contribution_date <= %2
+      AND ccr.cancel_date IS NULL
   ";
 
   $dao = CRM_Core_DAO::executeQuery($sql, [

--- a/templates/CRM/OfflineRecurring/Form/RecurringContribution.tpl
+++ b/templates/CRM/OfflineRecurring/Form/RecurringContribution.tpl
@@ -13,10 +13,10 @@
       <tr><td>&nbsp;</td><td>{ts}{$form.frequency_interval.label}{/ts} &nbsp;{$form.frequency_interval.html} &nbsp; {$form.frequency_unit.html}</td></tr>
       <tr><td class="label">{$form.start_date.label}</td><td>{$form.start_date.html}</td></tr>
       <tr><td class="label">{$form.next_sched_contribution_date.label}</td><td>{$form.next_sched_contribution_date.html}<br />
-        <div class="description">{ts}This is the date the contribution record will be created for the recurring payment (by the background process). If you want the first contribution on the start date, this should be same as start date.{/ts}</div>
+        <div class="description">{ts}This is the date the next contribution will be created.  It can be up to 7 days in the past, or any day from today onward.{/ts}</div>
       </td></tr>
       <tr><td class="label">{$form.end_date.label}</td><td>{$form.end_date.html}<br/>
-        <div class="description">{ts}Please specify end date only if you want to end the recurring contribution. Else leave it blank.<br /><b>Please note: No contribution record will be created (by the background process) for the contact, if end date is specified</b>.{/ts}</div>
+        <div class="description">{ts}You can leave the end date blank to continue the recurring contribution series indefinitely.{/ts}</div>
       </td></tr>
       <tr><td class="label">{$form.financial_type_id.label}</td><td>{$form.financial_type_id.html}</td></tr>
       <tr><td class="label">{$form.payment_instrument_id.label}</td><td>{$form.payment_instrument_id.html}</td></tr>


### PR DESCRIPTION
The main bug fix here is the SQL statement - since it pulls `ccr.id` and `ccro.id`, `$dao->id` ends up being the wrong ID, and the recurring contribution never gets updated with the next date (unless you didn't already have recurring contributions in your db).

I also made `next_sched_contribution_date` required and updated the on-screen documentation.